### PR TITLE
Reduce the size of the query string to avoid overrunning it

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,36 @@ const theme = extendTheme({
   },
 });
 
+function coordinateOverridesToLocalStorageValue(coordinateOverrides, epic) {
+  function firstValue(obj) {
+    return Object.values(obj)[0];
+  }
+
+  const isOldFormat =
+    typeof firstValue(coordinateOverrides) === "object" &&
+    typeof firstValue(firstValue(coordinateOverrides)) === "object";
+
+  if (isOldFormat) {
+    // Support coordinateOverrides[epic] to migrate legacy data.
+    return coordinateOverrides[epic]
+      ? Object.entries(coordinateOverrides[epic]).reduce(
+          (overrides, [key, value]) => {
+            // Reduce decimal places to one to save space.
+            overrides[key] = {
+              x: value.x.toFixed(1),
+              y: value.y.toFixed(1),
+            };
+
+            return overrides;
+          },
+          {}
+        )
+      : {};
+  }
+
+  return coordinateOverrides;
+}
+
 // TODO: Make this and the parameter hooks nicer.
 function bootstrapParameters() {
   const url = new URL(window.location);
@@ -51,34 +81,68 @@ function bootstrapParameters() {
     { key: "pipelineColors", isObject: true },
     { key: "additionalColors", isObject: true },
     { key: "pipelineHidden", isObject: true },
-    { key: "coordinateOverrides", isObject: true },
-  ].forEach(({ key, parse = (v) => v, isObject }) => {
-    if (url.searchParams.has(key)) {
-      const value = isObject
-        ? JSON.parse(url.searchParams.get(key))
-        : parse(url.searchParams.get(key));
+    {
+      key: "coordinateOverrides",
+      isObject: true,
+      toLocalStorage: (coordinateOverrides) => {
+        // By now the epic should be set. If not, bail out.
+        const epic = url.searchParams.get("epic");
+        if (!epic) return null;
 
-      // Local storage is always JSON.stringified.
-      localStorage.setItem(key, JSON.stringify(value));
-    } else {
-      const localValue = localStorage.getItem(key);
-      if (!localValue) return;
+        return {
+          localStorageKey: `coordinateOverrides-${epic}`,
+          localStorageValue: coordinateOverridesToLocalStorageValue(
+            coordinateOverrides,
+            epic
+          ),
+        };
+      },
+      fromLocalStorage: () => {
+        const epic = url.searchParams.get("epic");
+        if (!epic) return null;
 
-      let parsedValue;
-      try {
-        parsedValue = JSON.parse(localValue);
-      } catch (err) {
-        console.log("JSON parse error", err);
-      }
-      if (parsedValue) {
-        url.searchParams.set(
-          key,
-          isObject ? JSON.stringify(localValue) : localValue
+        return {
+          localStorageKey: `coordinateOverrides-${epic}`,
+        };
+      },
+    },
+  ].forEach(
+    ({ key, parse = (v) => v, isObject, toLocalStorage, fromLocalStorage }) => {
+      if (url.searchParams.has(key)) {
+        const value = isObject
+          ? JSON.parse(url.searchParams.get(key))
+          : parse(url.searchParams.get(key));
+
+        const { localStorageKey, localStorageValue } =
+          toLocalStorage?.(value) || {};
+
+        // Local storage is always JSON.stringified.
+        localStorage.setItem(
+          localStorageKey || key,
+          JSON.stringify(localStorageValue || value)
         );
-        window.history.pushState({}, undefined, url);
+      } else {
+        const { localStorageKey } = fromLocalStorage?.() || {};
+
+        const localValue = localStorage.getItem(localStorageKey || key);
+        if (!localValue) return;
+
+        let parsedValue;
+        try {
+          parsedValue = JSON.parse(localValue);
+        } catch (err) {
+          console.log("JSON parse error", err);
+        }
+        if (parsedValue) {
+          url.searchParams.set(
+            key,
+            isObject ? JSON.stringify(localValue) : localValue
+          );
+          window.history.pushState({}, undefined, url);
+        }
       }
     }
-  });
+  );
 }
 
 bootstrapParameters();
@@ -88,6 +152,9 @@ function App({ authentication, panel }) {
 
   const [APIKey, saveAPIKey] = useLocalStorage("zenhubAPIKey", "");
   const [appSettings, saveAppSettings] = useParameter("appSettings", {});
+  const [workspace, saveWorkspace] = useParameter("workspace", "");
+  const [epic, saveEpic] = useParameter("epic", "");
+  const [sprint, saveSprint] = useParameter("sprint", "");
   const [pipelineColors, savePipelineColors] = useParameter(
     "pipelineColors",
     pipelineColorDefaults
@@ -102,12 +169,10 @@ function App({ authentication, panel }) {
     {}
   );
   const [coordinateOverrides, saveCoordinateOverrides] = useParameter(
-    `coordinateOverrides`,
-    {}
+    `coordinateOverrides-${epic}`,
+    {},
+    `coordinateOverrides`
   );
-  const [workspace, saveWorkspace] = useParameter("workspace", "");
-  const [epic, saveEpic] = useParameter("epic", "");
-  const [sprint, saveSprint] = useParameter("sprint", "");
   const [epicIssue, setEpicIssue] = useState(); // TODO: Remove epicIssue if no longer used.
   const [nonEpicIssues, setNonEpicIssues] = useState();
   const [selfContainedIssues, setSelfContainedIssues] = useState();

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -326,7 +326,17 @@ export default function Header({
                     <Select
                       options={epicOptions}
                       value={chosenEpic}
-                      onChange={(chosenEpic) => saveEpic(chosenEpic.value)}
+                      onChange={(chosenEpic) => {
+                        // Clear the coordinate overrides from the query string when changing epics,
+                        // so the coords for the new epic can be loaded from localStorage.
+                        // TODO, a big refactor is needed to handle params and state better.
+
+                        const url = new URL(window.location);
+                        url.searchParams.delete("coordinateOverrides");
+                        window.history.pushState({}, undefined, url);
+
+                        saveEpic(chosenEpic.value);
+                      }}
                     />
                   </Box>
                 </FormControl>

--- a/src/components/SettingsModal/SettingsModal.js
+++ b/src/components/SettingsModal/SettingsModal.js
@@ -189,7 +189,7 @@ export default function SettingsModal({
               }}
             />
           </FormControl>
-          {Object.keys(coordinateOverrides[epic] || {}).length > 0 && (
+          {Object.keys(coordinateOverrides || {}).length > 0 && (
             <FormControl pt="5">
               <FormLabel>
                 Reset epic layout (takes effect immediately)
@@ -198,9 +198,7 @@ export default function SettingsModal({
                 colorScheme="blue"
                 mr={1}
                 onClick={() => {
-                  const newCoordinateOverrides = { ...coordinateOverrides };
-                  delete newCoordinateOverrides[epic];
-                  saveCoordinateOverrides(newCoordinateOverrides);
+                  saveCoordinateOverrides(null);
                 }}
               >
                 Reset layout

--- a/src/d3/index.js
+++ b/src/d3/index.js
@@ -12,7 +12,7 @@ import { getRectDimensions } from "./utils";
 import { renderDetailedIssues } from "./detailed-issues";
 import { renderSimpleIssues } from "./simple-issues";
 
-function toFixedDecimalPlaces(value, decimalPlaces) {
+export function toFixedDecimalPlaces(value, decimalPlaces) {
   return Number(
     Math.round(parseFloat(value + "e" + decimalPlaces)) + "e-" + decimalPlaces
   );

--- a/src/d3/index.js
+++ b/src/d3/index.js
@@ -304,8 +304,8 @@ export const generateGraph = (
     });
   }
 
-  if (Object.keys(coordinateOverrides[epic] || {}).length) {
-    applyOverrides(dag.proots || [dag], coordinateOverrides[epic]);
+  if (Object.keys(coordinateOverrides || {}).length) {
+    applyOverrides(dag.proots || [dag], coordinateOverrides);
   }
 
   const svgSelection = d3.select(svgElement);
@@ -588,11 +588,8 @@ export const generateGraph = (
       // console.log("ended", newX, d3.select(this).datum().data.id);
       saveCoordinateOverrides({
         ...coordinateOverrides,
-        [epic]: {
-          ...coordinateOverrides[epic],
-          // TODO do we have a `d` arg?
-          [d3.select(this).datum().data.id]: { x: newX, y: newY },
-        },
+        // TODO do we have a `d` arg?
+        [d3.select(this).datum().data.id]: { x: newX, y: newY },
       });
     }
   }

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -24,6 +24,10 @@ export const useLocalStorage = (key, defaultValue) => {
   });
 
   useEffect(() => {
+    setValue(getStorageValue(key));
+  }, [key]);
+
+  useEffect(() => {
     // Storing input.
     localStorage.setItem(key, JSON.stringify(value));
   }, [key, value]);

--- a/src/hooks/useParameter.js
+++ b/src/hooks/useParameter.js
@@ -2,7 +2,7 @@ import { useEffect } from "react";
 import { useLocalStorage } from "./useLocalStorage";
 
 // Parameters are always primitives, in order to make the query params more friendly (i.e. no JSON.stringify-quoted string query params).
-export const useParameter = (key, defaultValue) => {
+export const useParameter = (key, defaultValue, searchParamKey) => {
   const [localStorageValue, saveLocalStorageValue] = useLocalStorage(
     key,
     defaultValue
@@ -12,16 +12,16 @@ export const useParameter = (key, defaultValue) => {
     const url = new URL(window.location);
     if (localStorageValue) {
       url.searchParams.set(
-        key,
+        searchParamKey || key,
         typeof localStorageValue === "object"
           ? JSON.stringify(localStorageValue)
           : localStorageValue
       );
     } else {
-      url.searchParams.delete(key);
+      url.searchParams.delete(searchParamKey || key);
     }
     window.history.pushState({}, undefined, url);
-  }, [key, localStorageValue]);
+  }, [key, localStorageValue, searchParamKey]);
 
   return [localStorageValue, saveLocalStorageValue];
 };


### PR DESCRIPTION
- Only store the coordinate overrides for the current epic in the query string.
- Migrate previously stored values to the new storage format.